### PR TITLE
Multiple corrections to the instructions here.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Inventory database is now setup in local container.
     # cf ic login
     ```
 
+5. Check that your organization has set a namespace.
+    ```
+    # cf ic namespace get
+    ```
+
+5. If there is no namespace set for your , then set a namespace.
+    ```
+    # cf ic namespace get
+    ```
+
 4. Tag and push mysql database server image to your Bluemix private registry namespace.
     ```
     # docker tag cloudnative/mysql registry.ng.bluemix.net/$(cf ic namespace get)/mysql:cloudnative

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This database will be managed by refarch-cloudnative-micro-inventory microservice.
 
 ### Setup Inventory Database on Local MySQL Container
-1. Clone git repository.
+1. Clone git repository. If you cloned the peer repositories **`./clonePeers.sh`**, then you should not do a *`git clone`* 
     ```
     # git clone https://github.com/ibm-cloud-architecture/refarch-cloudnative-mysql.git
-    # cd refarch-cloudnative-sql
+    # cd refarch-cloudnative-mysql
     ```
 
 2. Create MySQL container with database `inventorydb`. This database can be connected at `<docker-host-ipaddr/hostname>:3306` as `dbuser` using `password`.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ Inventory database is now setup in local container.
 1. Clone git repository.
     ```
     # git clone https://github.com/ibm-cloud-architecture/refarch-cloudnative-mysql.git
-    # cd refarch-cloudnative-sql
+    ```
+
+2. Change to the directory of the repository.
+    ```
+    # cd refarch-cloudnative-mysql
     ```
 
 2. Build docker image using the Dockerfile from repo.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This database will be managed by refarch-cloudnative-micro-inventory microservice.
 
 ### Setup Inventory Database on Local MySQL Container
-1. Clone git repository. If you cloned the peer repositories **`./clonePeers.sh`**, then you should not do a *`git clone`* 
+1. Clone git repository. If you cloned the peer repositories **`./clonePeers.sh`**, then you should not do a *`git clone`*
     ```
     # git clone https://github.com/ibm-cloud-architecture/refarch-cloudnative-mysql.git
     # cd refarch-cloudnative-mysql
@@ -27,11 +27,11 @@ This database will be managed by refarch-cloudnative-micro-inventory microservic
     mysql> quit
     # exit
     ```
-   
+
 Inventory database is now setup in local container.
 
 ### Setup Inventory Database in IBM Bluemix container
-1. Clone git repository.
+1. Clone git repository. If you cloned the peer repositories **`./clonePeers.sh`**, then you should not do a *`git clone`*
     ```
     # git clone https://github.com/ibm-cloud-architecture/refarch-cloudnative-mysql.git
     ```


### PR DESCRIPTION
Added comment about not needing to clone this repo if the clone peers scripts was run on the main repo. Also added a test to see if the organization has a namespace set. Without a namespace, the container tag will fail. 
